### PR TITLE
CSS Fixes

### DIFF
--- a/app/views/sessions/new.html
+++ b/app/views/sessions/new.html
@@ -22,7 +22,7 @@ template: about
 
             <li>
               <label>Password</label>
-              <input type="password" data-prop="password" placeholder="Enter Your Email Address">
+              <input type="password" data-prop="password" placeholder="Enter Your Password">
             </li>
 
             <li>

--- a/public/css/style.css
+++ b/public/css/style.css
@@ -584,7 +584,7 @@ h3 {
 }
 
 @supports (mix-blend-mode: lighten) {
-	
+
   .gradient-text {
 	display: inline-block;
 	font-family: 'Montserrat', sans-serif;
@@ -930,7 +930,7 @@ fieldset label {
 	height: 39px;
 	background-color: #fff;
 }
-input[type="text"], input[type="password"] {
+input[type="text"], input[type="email"], input[type="password"] {
 	height: 35px;
 	margin: 0;
 	padding: 0 0 0 6px;


### PR DESCRIPTION

Corrected text on Login screen to say Enter Your Password  
Corrected the placeholder for password on Login screen to say "Enter Your Password" instead of "Enter Your Email Address"

Corrected the CSS to format the email field on the Create Account page. This way the input fields are the same size on screen.