### PR TITLE
Fix three bhm bugs

### DIFF
--- a/app/lib/bindings/bhm_events.rb
+++ b/app/lib/bindings/bhm_events.rb
@@ -5,9 +5,8 @@ Pakyow::App.bindings :bhm_events do
         restful :bhm_events
 
         binding(:should_restrict_event_starttime) do
-            people = People[cookies[:people]]
             {
-                :content => if (!people.nil? && !people.admin.nil? && people.admin) then "false" else "true" end
+                :content => if logged_in_user_is_bhm_admin_or_site_admin() then "false" else "true" end
             }
         end
 
@@ -181,8 +180,7 @@ Pakyow::App.bindings :bhm_events do
 
         binding(:websiteadmin_fieldset) do
             visible = "hide"
-            people = People[cookies[:people]]
-            isSiteAdmin = people != nil && people.admin != nil && people.admin == true
+            isSiteAdmin = logged_in_user_is_bhm_admin_or_site_admin()
             if isSiteAdmin
                 visible = "show"
             end

--- a/app/lib/bindings/main_menu.rb
+++ b/app/lib/bindings/main_menu.rb
@@ -135,7 +135,7 @@ Pakyow::App.bindings :main_menu do
 		unless cookies[:people].nil? || cookies[:people] == 0
 			person = People[cookies[:people]]
 			unless person.nil?
-				if logged_in_user_is_bhm_admin_or_site_admin()
+				if logged_in_user_is_bhm_manager_or_site_admin()
 					content = "Manage BHM Events"
 					href = "/bhm_events/manage"
 					splat = request.path.split("/")

--- a/app/lib/helpers.rb
+++ b/app/lib/helpers.rb
@@ -506,7 +506,7 @@ module Pakyow::Helpers
     return true
   end
 
-  def logged_in_user_is_bhm_site_admin_or_site_admin()
+  def logged_in_user_is_bhm_admin_or_site_admin()
     people = People[cookies[:people]]
     if people.nil?
       return false
@@ -523,7 +523,7 @@ module Pakyow::Helpers
     end
   end
 
-  def logged_in_user_is_bhm_admin_or_site_admin()
+  def logged_in_user_is_bhm_manager_or_site_admin()
     people = People[cookies[:people]]
     if people.nil?
       return false

--- a/app/lib/routes/_shared.rb
+++ b/app/lib/routes/_shared.rb
@@ -51,6 +51,12 @@ module SharedRoutes
   end
 
   fn :is_bhm_event_manager do
+    if logged_in_user_is_bhm_manager_or_site_admin() == false
+      redirect "/errors/403"
+    end
+  end
+
+  fn :is_bhm_event_admin do
     if logged_in_user_is_bhm_admin_or_site_admin() == false
       redirect "/errors/403"
     end

--- a/app/lib/routes/bhm_events.rb
+++ b/app/lib/routes/bhm_events.rb
@@ -28,7 +28,7 @@ Pakyow::App.routes(:bhm) do
                 view.scope(:main_menu).apply(request)
             end
 
-            get 'approve/:bhm_events_id', :before => :is_admin_check do
+            get 'approve/:bhm_events_id', :before => :is_bhm_event_admin do
                 success = 'failure'
                 if params[:bhm_events_id].is_number? == false
                 redirect "/errors/404"
@@ -48,7 +48,7 @@ Pakyow::App.routes(:bhm) do
                 send success
             end
 
-            get 'unapprove/:bhm_events_id', :before => :is_admin_check do
+            get 'unapprove/:bhm_events_id', :before => :is_bhm_event_admin do
                 success = 'failure'
                 if params[:bhm_events_id].is_number? == false
                 redirect "/errors/404"
@@ -79,7 +79,7 @@ Pakyow::App.routes(:bhm) do
                 if event.nil?
                 redirect "/errors/404"
                 end
-                isNotSiteAdmin = !logged_in_user_is_bhm_site_admin_or_site_admin()
+                isNotSiteAdmin = !logged_in_user_is_bhm_admin_or_site_admin()
                 if event.approved && isNotSiteAdmin
                 redirect "/errors/404"
                 end
@@ -171,7 +171,7 @@ Pakyow::App.routes(:bhm) do
                 "start_datetime" => parsed_time.to_datetime.utc,
                 "duration" => params[:bhm_events][:duration].to_i,
                 "venue_id" => params[:bhm_events][:venue].to_i,
-                "approved" => if logged_in_user_is_bhm_site_admin_or_site_admin() then true else false end,
+                "approved" => if logged_in_user_is_bhm_admin_or_site_admin() then true else false end,
                 "parent_id" => if params[:bhm_events][:parent_event_selector].blank? then "" else params[:bhm_events][:parent_event_selector].to_i end,
                 "flyer_category" => if params[:bhm_events][:flyer_category].nil? || params[:bhm_events][:flyer_category].empty? then group.flyer_category else params[:bhm_events][:flyer_category] end,
                 "flyer_fa_icon" => if params[:bhm_events][:flyer_fa_icon].nil? || params[:bhm_events][:flyer_fa_icon].empty? then group.flyer_fa_icon else params[:bhm_events][:flyer_fa_icon] end,
@@ -203,7 +203,7 @@ Pakyow::App.routes(:bhm) do
             venue_id = params[:bhm_events][:venue].to_i
             minutes_between_old_and_new_date = (((parsed_datetime - event.start_datetime.to_datetime)*24*60).to_i).abs
 
-            if logged_in_user_is_bhm_site_admin_or_site_admin() == false && (minutes_between_old_and_new_date > 0.99 || venue_id != event.venue_id)
+            if logged_in_user_is_bhm_admin_or_site_admin() == false && (minutes_between_old_and_new_date > 0.99 || venue_id != event.venue_id)
                 event.approved = false
             end
             event.name = params[:bhm_events][:name]


### PR DESCRIPTION
Fix three bhm bugs:
Unapprove for non-admin. Shows button but logic is broken to allow for
unapproval.

Event icon / category entry boxes do not show for bhm admin.

Cut off date for non admins