### PR TITLE
Hide the people directory from the navigation menu

### DIFF
--- a/app/views/_main_nav.html
+++ b/app/views/_main_nav.html
@@ -1,9 +1,6 @@
 <nav data-scope="main_menu">
 	<ul data-prop="first_container" class="pages">
 		<li>
-			<a data-prop="people_link" href="/people">People</a>
-		</li>
-		<li>
 			<a data-prop="groups_link" href="/groups">Groups</a>
 		</li>
 		<li>


### PR DESCRIPTION
This is meant to be a short term solution to the privacy mentioned at CoWorking Night